### PR TITLE
Make graphviz and matplotlib optional

### DIFF
--- a/ActionTree/__init__.py
+++ b/ActionTree/__init__.py
@@ -12,12 +12,6 @@ import pickle
 import sys
 import threading
 
-# We import matplotlib in the functions that need it because
-# upgrading it while using it leads to segfault. And we upgrade
-# it via devlpr, that uses ActionTree.
-import graphviz
-
-
 libc = ctypes.CDLL(None)
 try:
     stdout = ctypes.c_void_p.in_dll(libc, "stdout")
@@ -514,6 +508,7 @@ class DependencyGraph(object):
     """
 
     def __init__(self, action):
+        import graphviz
         self.__graphviz_graph = graphviz.Digraph("action", node_attr={"shape": "box"})
         nodes = {}
         for (i, action) in enumerate(action.get_possible_execution_order()):

--- a/README.rst
+++ b/README.rst
@@ -51,6 +51,10 @@ Install from PyPI::
 
     $ pip install ActionTree
 
+With dependencies to create Gantt charts and dependency graphs::
+
+    $ pip install 'ActionTree[dependency_graphs,gantt]'
+
 Import:
 
 >>> from ActionTree import execute

--- a/doc/user_guide/drawings.rst
+++ b/doc/user_guide/drawings.rst
@@ -13,6 +13,11 @@ Drawings
 Gantt chart
 -----------
 
+ActionTree uses `matplotlib`_ to visualize Gantt charts. Install all
+required dependencies with ``pip install ActionTree[gantt]``.
+
+.. _`matplotlib`: https://pypi.python.org/pypi/matplotlib
+
 You can draw a Gantt chart of the execution with :class:`.GanttChart`:
 
 >>> from ActionTree import GanttChart
@@ -52,6 +57,14 @@ False
 
 Dependency graph
 ----------------
+
+ActionTree uses `graphviz`_ to visualize dependency graphs. Install all
+required dependencies with ``pip install
+ActionTree[dependency_graphs]``.
+
+.. _`graphviz`: https://pypi.python.org/pypi/graphviz
+
+Dependency graphs need
 
 You can draw a dependency graph with :class:`.DependencyGraph`:
 

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,11 @@ setuptools.setup(
         "Programming Language :: Python :: 3.6",
         "Topic :: Software Development",
     ],
-    install_requires=["graphviz", "matplotlib"],
+    install_requires=[],
+    extras_require={
+        "dependency_graphs": ["graphviz"],
+        "gantt": ["matplotlib"],
+    },
     tests_require=py2_only("mock"),
     test_suite="ActionTree.tests",
     use_2to3=True,


### PR DESCRIPTION
Both dependencies are no requirement for the core functionality and rather add analytical sugar.